### PR TITLE
feat: Migración de Nodemailer a Resend con dominio propio

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.6.0.tgz",
@@ -564,6 +570,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1167,15 +1179,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/nodemailer": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
-      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/nodemon": {
       "version": "3.1.14",
       "resolved": "https://registry.npmmirror.com/nodemon/-/nodemon-3.1.14.tgz",
@@ -1367,6 +1370,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmmirror.com/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1471,6 +1480,27 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmmirror.com/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/router": {
@@ -1678,6 +1708,16 @@
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz",
@@ -1715,6 +1755,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmmirror.com/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/to-regex-range": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,13 +20,19 @@
         "multer": "^2.1.1",
         "multer-storage-cloudinary": "^4.0.0",
         "mysql2": "^3.22.1",
-        "nodemailer": "^8.0.7",
         "passport": "^0.7.0",
-        "passport-google-oauth20": "^2.0.0"
+        "passport-google-oauth20": "^2.0.0",
+        "resend": "^6.12.3"
       },
       "devDependencies": {
         "nodemon": "^3.1.14"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
@@ -588,6 +594,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1190,15 +1202,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/nodemailer": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
-      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/nodemon": {
       "version": "3.1.14",
       "resolved": "https://registry.npmmirror.com/nodemon/-/nodemon-3.1.14.tgz",
@@ -1390,6 +1393,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmmirror.com/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1494,6 +1503,27 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmmirror.com/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/router": {
@@ -1701,6 +1731,16 @@
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz",
@@ -1738,6 +1778,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmmirror.com/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "multer": "^2.1.1",
     "multer-storage-cloudinary": "^4.0.0",
     "mysql2": "^3.22.1",
-    "nodemailer": "^8.0.7",
     "passport": "^0.7.0",
-    "passport-google-oauth20": "^2.0.0"
+    "passport-google-oauth20": "^2.0.0",
+    "resend": "^6.12.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"

--- a/src/config/email.js
+++ b/src/config/email.js
@@ -1,17 +1,18 @@
-const nodemailer = require('nodemailer');
+// ============================================================
+// ARIA — Servicio de correo con Resend
+// Dominio: ariaproyecto.online
+// Funciona en cualquier red — reemplaza Nodemailer
+// ============================================================
 
-const transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASS,
-  }
-});
+const { Resend } = require('resend');
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM   = `ARIA Rescate Animal <aria@ariaproyecto.online>`;
 
 // Email con código OTP de 6 dígitos
 const enviarOTP = async (email, codigo, nombre) => {
-  await transporter.sendMail({
-    from: `"ARIA - Rescate Animal" <${process.env.EMAIL_USER}>`,
+  const { data, error } = await resend.emails.send({
+    from: FROM,
     to: email,
     subject: 'Verifica tu cuenta ARIA',
     html: `
@@ -38,12 +39,19 @@ const enviarOTP = async (email, codigo, nombre) => {
       </div>
     `
   });
+
+  if (error) {
+    console.error('Error Resend OTP:', JSON.stringify(error));
+    throw new Error(error.message || 'Error al enviar correo OTP');
+  }
+
+  console.log('OTP enviado a:', email, '| ID:', data?.id);
 };
 
-// Email con Magic Link (auto-login)
+// Email con Magic Link
 const enviarMagicLink = async (email, nombre, enlaceVerificacion) => {
-  await transporter.sendMail({
-    from: `"ARIA - Rescate Animal" <${process.env.EMAIL_USER}>`,
+  const { data, error } = await resend.emails.send({
+    from: FROM,
     to: email,
     subject: 'Activa tu cuenta ARIA',
     html: `
@@ -55,27 +63,34 @@ const enviarMagicLink = async (email, nombre, enlaceVerificacion) => {
         <div style="background:white;border-radius:12px;padding:1.5rem;border:1px solid #e2e8f0;">
           <h2 style="color:#0f172a;margin:0 0 0.75rem;font-size:1.1rem;">Bienvenido, ${nombre}</h2>
           <p style="color:#475569;margin:0 0 1.5rem;line-height:1.6;font-size:0.875rem;">
-            Tu cuenta ha sido creada exitosamente. Haz clic en el boton para verificar tu correo e ingresar directamente a la plataforma.
+            Tu cuenta ha sido creada exitosamente. Haz clic en el boton para verificar tu correo.
           </p>
           <div style="text-align:center;margin-bottom:1.25rem;">
-            <a href="${enlaceVerificacion}" 
+            <a href="${enlaceVerificacion}"
                style="display:inline-block;background:#2563eb;color:white;padding:0.875rem 2rem;border-radius:12px;text-decoration:none;font-weight:700;font-size:1rem;">
               Verificar mi cuenta
             </a>
           </div>
           <p style="color:#94a3b8;font-size:0.75rem;margin:0;text-align:center;">
-            Este enlace expira en 24 horas. Si no creaste esta cuenta, ignora este correo.
+            Este enlace expira en 24 horas.
           </p>
         </div>
       </div>
     `
   });
+
+  if (error) {
+    console.error('Error Resend MagicLink:', JSON.stringify(error));
+    throw new Error(error.message || 'Error al enviar Magic Link');
+  }
+
+  console.log('MagicLink enviado a:', email, '| ID:', data?.id);
 };
 
-// Email de recuperación de contraseña con OTP
+// Email OTP recuperacion de contrasena
 const enviarOTPRecuperacion = async (email, nombre, codigo) => {
-  await transporter.sendMail({
-    from: `"ARIA - Rescate Animal" <${process.env.EMAIL_USER}>`,
+  const { data, error } = await resend.emails.send({
+    from: FROM,
     to: email,
     subject: 'Recupera tu contrasena - ARIA',
     html: `
@@ -102,6 +117,13 @@ const enviarOTPRecuperacion = async (email, nombre, codigo) => {
       </div>
     `
   });
+
+  if (error) {
+    console.error('Error Resend Recuperacion:', JSON.stringify(error));
+    throw new Error(error.message || 'Error al enviar OTP recuperacion');
+  }
+
+  console.log('OTP recuperacion enviado a:', email, '| ID:', data?.id);
 };
 
 module.exports = { enviarOTP, enviarMagicLink, enviarOTPRecuperacion };


### PR DESCRIPTION
Descripción

Se reemplazó Nodemailer por Resend como servicio de envío de correos, configurando el dominio ariaproyecto.online con registros DNS en Hostinger. Los correos OTP ahora se envían desde aria@ariaproyecto.online y llegan correctamente a cualquier destinatario desde cualquier red, incluyendo redes restrictivas como Selvanet que bloqueaban el envío anterior.
 
Numero de la tarea
#30 

<img width="1355" height="721" alt="image" src="https://github.com/user-attachments/assets/c105d148-f9ca-4d3c-8fe0-2798f1e61ae7" />

<img width="1252" height="633" alt="image" src="https://github.com/user-attachments/assets/6b63200f-5e62-44ff-8800-6ac767dc55b1" />
